### PR TITLE
Implement custom toast system and global error handling

### DIFF
--- a/src/ErrorToast.css
+++ b/src/ErrorToast.css
@@ -1,0 +1,26 @@
+.error-toast {
+  background: #333;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+}
+.error-toast button {
+  margin-left: 0.5rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+.toast-container {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 9999;
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, ReactNode } from 'react';
+import { showErrorToast } from '../errorHandling';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info);
+    const message = error instanceof Error ? error.message : String(error);
+    showErrorToast(message);
+  }
+
+  render() {
+    if (this.state.hasError && this.props.fallback) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,43 @@
+import { ReactNode, useState } from 'react';
+import '../ErrorToast.css';
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+let addToastImpl: (message: string) => void;
+
+export function showToast(message: string) {
+  addToastImpl?.(message);
+}
+
+export default function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  addToastImpl = (message: string) => {
+    const id = Date.now() + Math.random();
+    setToasts((prev) => [...prev, { id, message }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 5000);
+  };
+
+  const dismiss = (id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  return (
+    <>
+      {children}
+      <div className="toast-container">
+        {toasts.map((t) => (
+          <div className="error-toast" key={t.id}>
+            <span style={{ flex: 1 }}>{t.message}</span>
+            <button onClick={() => dismiss(t.id)}>×</button>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/errorHandling.tsx
+++ b/src/errorHandling.tsx
@@ -1,0 +1,19 @@
+import { showToast } from './components/ToastProvider';
+
+export function showErrorToast(message: string) {
+  showToast(message);
+}
+
+export function initializeGlobalErrorHandling() {
+  window.onerror = function (message, source, line, column, error) {
+    const msg = error?.message || (typeof message === 'string' ? message : 'Unknown error');
+    showErrorToast(msg);
+    return false;
+  };
+
+  window.onunhandledrejection = function (event) {
+    const reason = event.reason;
+    const msg = reason instanceof Error ? reason.message : String(reason);
+    showErrorToast(msg);
+  };
+}

--- a/src/features/groceries/GroceriesMainScreen.tsx
+++ b/src/features/groceries/GroceriesMainScreen.tsx
@@ -5,14 +5,20 @@ import getRepositories from '@repositories';
 import { Container, ContainerFixedContent, ContainerScrollContent } from '@components/conteiners';
 import Icon from '@components/Icons';
 import { getExpirationLabel } from './expirationUtils';
+import { showErrorToast } from '../../errorHandling';
 import './GroceriesMainScreen.css';
 
 const GroceriesMainScreen = () => {
   const [items, setItems] = useState<GroceryItemModel[]>([]);
 
   useEffect(() => {
-    const { groceries } = getRepositories();
-    setItems(groceries.getAllSorted());
+    try {
+      const { groceries } = getRepositories();
+      setItems(groceries.getAllSorted());
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      showErrorToast(msg);
+    }
   }, []);
 
   return <Container spaced full>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,25 @@
 import './index.css';
 import ReactDOM from 'react-dom/client';
 
-import './global'
-import "./data/firebase/google-services";
+import './global';
+import './data/firebase/google-services';
 import { VarsProvider } from '@components/Vars';
 import App from './App';
+import ErrorBoundary from '@components/ErrorBoundary';
+import ToastProvider from './components/ToastProvider';
+import { initializeGlobalErrorHandling } from './errorHandling';
+
+initializeGlobalErrorHandling();
 
 
 ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 ).render(
   <VarsProvider>
-    <App />
+    <ErrorBoundary fallback={<div>Something went wrong.</div>}>
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </ErrorBoundary>
   </VarsProvider>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,6 +2600,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+
 "graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -3389,6 +3390,7 @@ __metadata:
   checksum: 10c0/3e26e89bb6c67c9a6aa86cb888c7a7f8258f2e347a6d2a15299c17eb16e04c19194e3452bc3255bd34000a61e45e2cb51e46292392340432f133e5a5d2dfb5fc
   languageName: node
   linkType: hard
+
 
 "react-is@npm:^16.13.1":
   version: 16.13.1


### PR DESCRIPTION
## Summary
- remove `react-hot-toast` dependency
- implement `ToastProvider` with custom CSS for bottom-center toasts
- wire global error handling to show toasts through the new provider
- wrap `App` with `ToastProvider` in the root

## Testing
- `yarn test`
- `yarn build` *(fails: No file was found to copy on /workspace/Site/resources src)*

------
https://chatgpt.com/codex/tasks/task_e_6885e55ed550832eb5ea679caadb0060