### PR TITLE
Add expiration label tests

### DIFF
--- a/src/features/groceries/__tests__/GroceriesMainScreen.test.tsx
+++ b/src/features/groceries/__tests__/GroceriesMainScreen.test.tsx
@@ -4,15 +4,18 @@ import { vi } from 'vitest';
 import GroceriesMainScreen from '../GroceriesMainScreen';
 import { GroceryItemModel, QuantityUnit } from '../../../data/models/GroceryItemModel';
 
-const items = [
-  new GroceryItemModel('1', 'Rice', 1, QuantityUnit.UN),
-  new GroceryItemModel('2', 'Beans', 2, QuantityUnit.UN),
-];
+let items: GroceryItemModel[] = [];
 
-vi.mock('../expirationUtils', () => ({ getExpirationLabel: () => undefined }));
-vi.mock('@repositories', () => ({ default: () => ({ groceries: { getAllSorted: () => items } }) }));
+vi.mock('@repositories', () => ({
+  default: () => ({ groceries: { getAllSorted: () => items } }),
+}));
 
 test('renders grocery items from repository', () => {
+  items = [
+    new GroceryItemModel('1', 'Rice', 1, QuantityUnit.UN),
+    new GroceryItemModel('2', 'Beans', 2, QuantityUnit.UN),
+  ];
+
   render(
     <MemoryRouter>
       <GroceriesMainScreen />
@@ -21,4 +24,28 @@ test('renders grocery items from repository', () => {
 
   expect(screen.getByText('Rice')).toBeInTheDocument();
   expect(screen.getByText('Beans')).toBeInTheDocument();
+});
+
+test('shows correct expiration labels based on date', () => {
+  const now = new Date();
+  const day = 1000 * 60 * 60 * 24;
+  items = [
+    new GroceryItemModel('1', 'Expired Item', 1, QuantityUnit.UN, undefined, new Date(now.getTime() - day)),
+    new GroceryItemModel('2', 'Soon Item', 1, QuantityUnit.UN, undefined, new Date(now.getTime() + 2 * day)),
+    new GroceryItemModel('3', 'Week Item', 1, QuantityUnit.UN, undefined, new Date(now.getTime() + 5 * day)),
+    new GroceryItemModel('4', 'Month Item', 1, QuantityUnit.UN, undefined, new Date(now.getTime() + 20 * day)),
+    new GroceryItemModel('5', 'Valid Item', 1, QuantityUnit.UN, undefined, new Date(now.getTime() + 40 * day)),
+  ];
+
+  render(
+    <MemoryRouter>
+      <GroceriesMainScreen />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText(Lang.groceries.expired)).toBeInTheDocument();
+  expect(screen.getByText(Lang.groceries.expiringSoon)).toBeInTheDocument();
+  expect(screen.getByText(Lang.groceries.thisWeek)).toBeInTheDocument();
+  expect(screen.getByText(Lang.groceries.thisMonth)).toBeInTheDocument();
+  expect(screen.getByText(Lang.groceries.valid)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add expiration label verification in GroceriesMainScreen tests
- use real getExpirationLabel while mocking repository

## Testing
- `yarn test src/features/groceries/__tests__/GroceriesMainScreen.test.tsx`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6885ee6c9d94832eb10284ef5a41bbdc