### PR TITLE
feat: add speech recognition beta screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import RegistryScreenForm from '@features/accounts/RegistryScreenForm';
 import GroceriesMainScreen from '@features/groceries/GroceriesMainScreen';
 import GroceryItemForm from '@features/groceries/GroceryItemForm';
 import NotFoundScreen from '@features/commons/NotFoundScreen';
+import SpeechScreen from '@features/beta/SpeechScreen';
 
 import { clearRepositories, resetRepositories } from '@repositories';
 
@@ -48,6 +49,7 @@ const router = createBrowserRouter([
   { path: '/categories/create', element: <AddCategoriesScreen /> },
   { path: '/groceries/create', element: <GroceryItemForm /> },
   { path: '/groceries/:id/edit', element: <GroceryItemForm /> },
+  { path: '/beta/speech', element: <SpeechScreen /> },
   { path: '*', element: <EmptyScreen title='Not Found' /> },
 ])
 

--- a/src/features/beta/SpeechScreen.css
+++ b/src/features/beta/SpeechScreen.css
@@ -1,0 +1,38 @@
+.SpeechScreen {
+  position: relative;
+}
+
+.play-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.speech-textarea {
+  width: 100%;
+  resize: none;
+  overflow: hidden;
+  min-height: 200px;
+  font-size: 1rem;
+}
+
+.speech-marquee {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 90%;
+}
+
+.speech-marquee-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+}

--- a/src/features/beta/SpeechScreen.tsx
+++ b/src/features/beta/SpeechScreen.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from 'react';
+import Icon from '@components/Icons';
+import { Container, ContainerFixedContent, ContainerScrollContent } from '@components/conteiners';
+import './SpeechScreen.css';
+
+const LAST_CHARS = 100;
+
+const SpeechScreen = () => {
+  const [listening, setListening] = useState(false);
+  const [finalTranscript, setFinalTranscript] = useState('');
+  const [interimTranscript, setInterimTranscript] = useState('');
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const recognitionRef = useRef<any>(null);
+
+  useEffect(() => {
+    const SpeechRecognition: any = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) return;
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = 'pt-BR';
+    recognition.onresult = (event: any) => {
+      let interim = '';
+      let final = '';
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          final += result[0].transcript;
+        } else {
+          interim += result[0].transcript;
+        }
+      }
+      if (final) setFinalTranscript(prev => prev + final);
+      setInterimTranscript(interim);
+    };
+    recognition.onend = () => setListening(false);
+    recognitionRef.current = recognition;
+  }, []);
+
+  const startListening = () => {
+    if (recognitionRef.current && !listening) {
+      recognitionRef.current.start();
+      setListening(true);
+    }
+  };
+
+  const text = finalTranscript + interimTranscript;
+
+  useEffect(() => {
+    if (textAreaRef.current) {
+      textAreaRef.current.style.height = 'auto';
+      textAreaRef.current.style.height = textAreaRef.current.scrollHeight + 'px';
+    }
+  }, [text]);
+
+  const marqueeText = text.slice(-LAST_CHARS);
+
+  return (
+    <Container screen spaced className="SpeechScreen">
+      <ContainerFixedContent>
+        <button onClick={startListening} disabled={listening} className="play-button">
+          <Icon icon={Icon.all.faPlay} />
+        </button>
+      </ContainerFixedContent>
+      <ContainerScrollContent>
+        <textarea ref={textAreaRef} value={text} readOnly className="speech-textarea" />
+      </ContainerScrollContent>
+      <div className="speech-marquee">
+        <span className="speech-marquee-text">{marqueeText}</span>
+        <Icon icon={Icon.all.faMicrophone} />
+      </div>
+    </Container>
+  );
+};
+
+export default SpeechScreen;
+


### PR DESCRIPTION
## Summary
- add hidden beta speech recognition route
- implement speech recognition screen with auto-growing transcript and floating marquee

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6891dd06e4a4832ea9e25c3951846921