### PR TITLE
Refactor plan copy and comparison

### DIFF
--- a/src/features/subscriptions/SubscriptionsRouter.tsx
+++ b/src/features/subscriptions/SubscriptionsRouter.tsx
@@ -9,7 +9,7 @@ const SubscriptionsRouter: React.FC = () => (
   <Routes>
     <Route path="plans" element={<Plans />} />
     <Route path="why" element={<WhyWeCharge />} />
-    <Route path="why/cots" element={<CostsExplained />} />
+    <Route path="why/costs" element={<CostsExplained />} />
     <Route path="checkout/:plan" element={<Checkout />} />
     <Route path="thankyou" element={<ThankYou />} />
     <Route path="*" element={<Navigate to="plans" replace />} />

--- a/src/features/subscriptions/components/FeatureTable.tsx
+++ b/src/features/subscriptions/components/FeatureTable.tsx
@@ -1,36 +1,23 @@
+import { plans, comparisonTable } from '../planData';
 import './FeatureTable.css';
-
-interface Feature {
-  feature: string;
-  basic: boolean;
-  plus: boolean;
-  premium: boolean;
-}
-
-const features: Feature[] = [
-  { feature: 'Advanced insights', basic: false, plus: true, premium: true },
-  { feature: 'Cloud sync', basic: false, plus: true, premium: true },
-  { feature: 'Full export', basic: false, plus: false, premium: true },
-  { feature: 'Priority support', basic: false, plus: false, premium: true },
-];
 
 const FeatureTable: React.FC = () => (
   <table className="FeatureTable">
     <thead>
       <tr>
-        <th>Feature</th>
-        <th>Basic</th>
-        <th>Plus</th>
-        <th>Premium</th>
+        <th>Recurso</th>
+        {plans.map((p) => (
+          <th key={p.id}>{p.title}</th>
+        ))}
       </tr>
     </thead>
     <tbody>
-      {features.map((f) => (
-        <tr key={f.feature}>
-          <td>{f.feature}</td>
-          <td>{f.basic ? '✓' : '✗'}</td>
-          <td>{f.plus ? '✓' : '✗'}</td>
-          <td>{f.premium ? '✓' : '✗'}</td>
+      {comparisonTable.map((row) => (
+        <tr key={row.feature}>
+          <td>{row.feature}</td>
+          {row.values.map((v, i) => (
+            <td key={i}>{v}</td>
+          ))}
         </tr>
       ))}
     </tbody>

--- a/src/features/subscriptions/components/PlanCard.css
+++ b/src/features/subscriptions/components/PlanCard.css
@@ -18,3 +18,14 @@
   font-size: 24px;
   font-weight: bold;
 }
+
+.PlanCard ul {
+  text-align: left;
+  padding-left: 20px;
+  margin: 0;
+  flex-grow: 1;
+}
+
+.PlanCard button {
+  margin-top: auto;
+}

--- a/src/features/subscriptions/components/PlanCard.tsx
+++ b/src/features/subscriptions/components/PlanCard.tsx
@@ -4,23 +4,30 @@ import Button from '@components/common/Button';
 import './PlanCard.css';
 
 interface PlanCardProps {
+  id: string;
   title: string;
   price: string;
   description: string;
+  bullets: string[];
+  cta: string;
+  badge?: string;
   highlighted?: boolean;
 }
 
-const PlanCard: React.FC<PlanCardProps> = ({ title, price, description, highlighted }) => {
+const PlanCard: React.FC<PlanCardProps> = ({ id, title, price, description, bullets, cta, badge, highlighted }) => {
   const navigate = useNavigate();
   return (
     <div className={`PlanCard ${highlighted ? 'highlighted' : ''}`}>
-      {highlighted && <Badge>{Lang.subscriptions?.plans.badge || 'Most Popular'}</Badge>}
+      {badge && <Badge>{badge}</Badge>}
       <h3>{title}</h3>
       <div className="price">{price}</div>
       <p>{description}</p>
-      <Button onClick={() => navigate(`/subscriptions/checkout/${title.toLowerCase()}`)}>
-        {Lang.subscriptions?.plans.select || 'Choose'}
-      </Button>
+      <ul>
+        {bullets.map((b) => (
+          <li key={b}>{b}</li>
+        ))}
+      </ul>
+      <Button onClick={() => navigate(`/subscriptions/checkout/${id}`)}>{cta}</Button>
     </div>
   );
 };

--- a/src/features/subscriptions/i18n/base.ts
+++ b/src/features/subscriptions/i18n/base.ts
@@ -1,12 +1,4 @@
 export default interface SubscriptionsTranslation {
-  plans: {
-    badge: string;
-    select: string;
-    basic: { title: string; price: string; description: string; };
-    plus: { title: string; price: string; description: string; };
-    premium: { title: string; price: string; description: string; };
-    disclaimer: string;
-  };
   checkout: {
     payNow: string;
   };

--- a/src/features/subscriptions/i18n/ptBR.ts
+++ b/src/features/subscriptions/i18n/ptBR.ts
@@ -1,26 +1,6 @@
 import SubscriptionsTranslation from './base';
 
 const ptBR: SubscriptionsTranslation = {
-  plans: {
-    badge: 'Mais Popular',
-    select: 'Escolher',
-    basic: {
-      title: 'Basic',
-      price: 'R$ 0/mês',
-      description: 'Grátis para sempre, ferramentas essenciais para quem está começando nas finanças pessoais.'
-    },
-    plus: {
-      title: 'Plus',
-      price: 'R$ 15/mês',
-      description: 'Plano mensal acessível, inclui insights avançados e sincronização na nuvem.'
-    },
-    premium: {
-      title: 'Premium',
-      price: 'R$ 30/mês',
-      description: 'Para usuários avançados, inclui exportação completa, integrações e suporte prioritário.'
-    },
-    disclaimer: 'Os valores existem para cobrir custos, garantir sustentabilidade e permitir que continuemos oferecendo acesso à educação financeira no Brasil.'
-  },
   checkout: {
     payNow: 'Pagar Agora'
   },

--- a/src/features/subscriptions/pages/CostsExplained.tsx
+++ b/src/features/subscriptions/pages/CostsExplained.tsx
@@ -1,3 +1,7 @@
+import { AI_TOKEN_RATIO } from '../planData';
+
+const { input, output } = AI_TOKEN_RATIO;
+
 const costs = [
   {
     title: 'Servidores & Banco de Dados',
@@ -11,7 +15,7 @@ const costs = [
   },
   {
     title: 'Inteligência Artificial',
-    description: 'Cada chamada à IA gera custo por token (entrada/saída de texto).',
+    description: `Cada chamada à IA gera custo por token (${input * 100}% entrada / ${output * 100}% saída).`,
     cost: '~R$ 0,02 a R$ 0,10 por 1.000 tokens'
   },
   {
@@ -42,10 +46,15 @@ const CostsExplained: React.FC = () => (
     <p><em>✨ Se você é designer ou tem experiência em UX (Experiência do Usuário), sua ajuda seria <strong>incrivelmente bem-vinda</strong>. Queremos tornar o app mais simples e acessível para pessoas com limitações de visão, motoras ou intelectuais.</em></p>
     <p>📩 Se quiser colaborar, entre em contato no Telegram: <a href="https://t.me/victorwads" target="_blank" rel="noreferrer">@victorwads</a></p>
     <h3>Como isso afeta os planos</h3>
-    <p><ul><li><strong>Plano Gratuito</strong>: custeado pelos assinantes, com limites para manter o uso viável.</li><li><strong>Plano Plus</strong>: cobre parte dos custos de IA, libera mais registros e relatórios avançados.</li><li><strong>Plano Premium</strong>: financia integrações extras, maior limite de registros e acesso prioritário a novos recursos.</li></ul></p>
-    <p>Em resumo: <strong>quanto mais avançado o plano, mais custos diretos ele cobre</strong> — e, ao mesmo tempo, mantém o plano gratuito vivo para quem precisa.</p>
+    <p><ul>
+      <li><strong>Plano Free</strong>: custeado pelos assinantes, com limites para manter o uso viável.</li>
+      <li><strong>Plano Basic</strong>: cobre parte dos custos de IA, libera mais registros e relatórios avançados.</li>
+      <li><strong>Plano Plus</strong>: melhor custo‑benefício: assistente fluido.</li>
+      <li><strong>Plano Pro</strong>: financia integrações extras, maior limite de registros e acesso prioritário a novos recursos.</li>
+    </ul></p>
+    <p>Em resumo: <strong>quanto mais avançado o plano, mais custos diretos ele cobre</strong> — e, ao mesmo tempo, mantém o plano Free vivo para quem precisa.</p>
     <h3>Reinvestindo em Todos</h3>
-    <p>Nenhum valor é retirado como lucro pessoal. Cada real arrecadado vai para pagar os custos de servidores, Firebase e IA, garantir que o plano gratuito continue existindo e trazer novos recursos e melhorias para todos.</p>
+    <p>Nenhum valor é retirado como lucro pessoal. Cada real arrecadado vai para pagar os custos de servidores, Firebase e IA, garantir que o plano Free continue existindo e trazer novos recursos e melhorias para todos.</p>
   </div>
 );
 

--- a/src/features/subscriptions/pages/Plans.tsx
+++ b/src/features/subscriptions/pages/Plans.tsx
@@ -1,34 +1,22 @@
+import { Link } from 'react-router-dom';
 import PlanCard from '../components/PlanCard';
 import FeatureTable from '../components/FeatureTable';
+import { plans, transparencyNote } from '../planData';
 
-const Plans: React.FC = () => {
-  const t = Lang.subscriptions?.plans;
-  return (
-    <div style={{ padding: 16 }}>
-      <div style={{ display: 'flex', gap: 16, justifyContent: 'center', flexWrap: 'wrap' }}>
-        <PlanCard
-          title={t?.basic.title || 'Basic'}
-          price={t?.basic.price || 'R$ 0/mês'}
-          description={t?.basic.description || 'Grátis para sempre, ferramentas essenciais para quem está começando nas finanças pessoais.'}
-        />
-        <PlanCard
-          title={t?.plus.title || 'Plus'}
-          price={t?.plus.price || 'R$ 15/mês'}
-          description={t?.plus.description || 'Plano mensal acessível, inclui insights avançados e sincronização na nuvem.'}
-          highlighted
-        />
-        <PlanCard
-          title={t?.premium.title || 'Premium'}
-          price={t?.premium.price || 'R$ 30/mês'}
-          description={t?.premium.description || 'Para usuários avançados, inclui exportação completa, integrações e suporte prioritário.'}
-        />
-      </div>
-      <FeatureTable />
-      <p style={{ marginTop: 24, textAlign: 'center' }}>
-        {t?.disclaimer || 'Os valores existem para cobrir custos, garantir sustentabilidade e permitir que continuemos oferecendo acesso à educação financeira no Brasil.'}
-      </p>
+const Plans: React.FC = () => (
+  <div style={{ padding: 16 }}>
+    <div style={{ display: 'flex', gap: 16, justifyContent: 'center', flexWrap: 'wrap' }}>
+      {plans.map((p) => (
+        <PlanCard key={p.id} {...p} />
+      ))}
     </div>
-  );
-};
+    <FeatureTable />
+    <p style={{ marginTop: 24, textAlign: 'center' }}>{transparencyNote}</p>
+    <p style={{ textAlign: 'center' }}>
+      <Link to="/subscriptions/why">Por que cobramos?</Link> ·{' '}
+      <Link to="/subscriptions/why/costs">Detalhes dos custos</Link>
+    </p>
+  </div>
+);
 
 export default Plans;

--- a/src/features/subscriptions/pages/WhyWeCharge.tsx
+++ b/src/features/subscriptions/pages/WhyWeCharge.tsx
@@ -5,27 +5,27 @@ const WhyWeCharge: React.FC = () => (
     <p><strong>Resumindo: a assinatura não é sobre lucro. Nós cobramos apenas o valor mínimo necessário para manter o projeto vivo. Qualquer sobra será totalmente reinvestida no próprio app — seja para criar novas funcionalidades para quem paga, seja para garantir que quem não pode pagar ainda consiga usar gratuitamente para organizar suas finanças possivelmente melhorando sua qualidade de vida.</strong></p>
     <section>
       <h2>Seção 1 – Introdução Honesta</h2>
-      <p>Acreditamos que educação financeira precisa ser acessível. Por isso, o nosso plano Básico é gratuito para sempre.
+      <p>Acreditamos que educação financeira precisa ser acessível. Por isso, o nosso plano Free é gratuito para sempre.
 Mas gratuito não significa sem limites: nós custeamos a infraestrutura essencial para que qualquer pessoa consiga organizar seus fluxos financeiros de forma simples e viável. Esse plano cobre o básico, sem custo para o usuário, mas com algumas restrições que garantem que possamos manter o serviço sem inviabilizar o projeto.</p>
-      <p>No plano gratuito, você terá:</p>
+      <p>No plano Free, você terá:</p>
       <ul>
         <li>Limite de registros, para evitar custos excessivos com banco de dados</li>
         <li>Uso de Inteligência Artificial apenas na abertura de contas, já que cada requisição de IA tem um custo bem alto!</li>
         <li>Recursos básicos de controle financeiro.</li>
       </ul>
       <p>Fazemos isso porque não temos dinheiro infinito. Nosso objetivo é oferecer o máximo viável de graça, dentro do que conseguimos sustentar, para que mesmo quem não tem como pagar tenha condições de melhorar a sua vida financeira.</p>
-      <p>Para mais detalhes dos nossos custos acesse <Link to="/subscriptions/why/cots">aqui</Link>.</p>
+      <p>Para mais detalhes dos nossos custos acesse <Link to="/subscriptions/why/costs">aqui</Link>.</p>
     </section>
     <section>
       <h2>Seção 2 – Por que existem planos pagos</h2>
-      <p>Com os planos Plus e Premium, conseguimos:</p>
+      <p>Com os planos Basic, Plus e Pro, conseguimos:</p>
       <ul>
         <li>Financiar a infraestrutura que mantém o app funcionando</li>
         <li>Investir em novas funcionalidades e melhorias</li>
         <li>Garantir estabilidade e segurança</li>
-        <li>Permitir que o plano gratuito continue existindo para quem precisa</li>
+        <li>Permitir que o plano Free continue existindo para quem precisa</li>
       </ul>
-      <p>Para mais detalhes dos nossos custos acesse <Link to="/subscriptions/why/cots">aqui</Link>.</p>
+      <p>Para mais detalhes dos nossos custos acesse <Link to="/subscriptions/why/costs">aqui</Link>.</p>
     </section>
     <section>
       <h2>Seção 3 – Nossos Custos</h2>
@@ -38,13 +38,13 @@ Mas gratuito não significa sem limites: nós custeamos a infraestrutura essenci
         <li>Suporte e recursos para a comunidade</li>
       </ul>
       <p>Esses custos não param de crescer, e precisamos garantir que o projeto seja sustentável no longo prazo.</p>
-      <p>Para mais detalhes dos nossos custos acesse <Link to="/subscriptions/why/cots">aqui</Link>.</p>
+      <p>Para mais detalhes dos nossos custos acesse <Link to="/subscriptions/why/costs">aqui</Link>.</p>
     </section>
     <section>
       <h2>Seção 4 – Com sua assinatura você ajuda!</h2>
       <p>Quando você assina, você não está apenas destravando funcionalidades extras. Você está financiando o acesso à educação financeira para milhares de pessoas no Brasil. O seu apoio garante que o projeto continue disponível e evoluindo, sem nunca virar um produto fechado apenas para quem pode pagar.</p>
     </section>
-    <p>Queremos deixar muito claro: não existe lucro pessoal aqui. Cada real arrecadado vai direto para pagar servidores, integrações e desenvolvimento. E se sobrar algo volta para o próprio app e para a comunidade do plano free. É assim que conseguimos manter o acesso gratuito e, ao mesmo tempo, oferecer ferramentas mais poderosas para quem escolhe contribuir.</p>
+    <p>Queremos deixar muito claro: não existe lucro pessoal aqui. Cada real arrecadado vai direto para pagar servidores, integrações e desenvolvimento. E se sobrar algo volta para o próprio app e para a comunidade do plano Free. É assim que conseguimos manter o acesso gratuito e, ao mesmo tempo, oferecer ferramentas mais poderosas para quem escolhe contribuir.</p>
   </div>
 );
 

--- a/src/features/subscriptions/planData.ts
+++ b/src/features/subscriptions/planData.ts
@@ -1,0 +1,116 @@
+export const AI_TOKEN_RATIO = {
+  input: 0.6,
+  output: 0.4,
+};
+
+export interface Plan {
+  id: string;
+  title: string;
+  price: string;
+  description: string;
+  bullets: string[];
+  cta: string;
+  badge?: string;
+  highlighted?: boolean;
+}
+
+export const plans: Plan[] = [
+  {
+    id: 'free',
+    title: 'Free',
+    price: 'R$0/mês',
+    description: 'Grátis para sempre. Sync ativo, IA só no setup inicial.',
+    bullets: [
+      '5.000 registros totais',
+      'IA no onboarding (1x) ou sua própria chave OpenAI',
+      'Sync ativo + devices ilimitados (limite de novos devices por mês)',
+    ],
+    cta: 'Começar agora',
+  },
+  {
+    id: 'basic',
+    title: 'Basic',
+    price: 'R$7,90/mês (≈ $1.50)',
+    description: 'Para começar com IA no dia a dia.',
+    bullets: [
+      '50.000 registros',
+      '1M tokens de IA/mês (gerenciados pelo app)',
+      'Devices ilimitados + novos devices sem limite prático (monitorado)',
+      'Pode usar sua própria chave OpenAI se preferir',
+    ],
+    cta: 'Assinar Basic',
+    badge: 'Entrada',
+  },
+  {
+    id: 'plus',
+    title: 'Plus',
+    price: 'R$14,90/mês (≈ $3.00)',
+    description: 'Melhor custo‑benefício: assistente fluido.',
+    bullets: [
+      '200.000 registros',
+      '5M tokens de IA/mês',
+      'Devices ilimitados + novos devices sem limite prático',
+      'Pode usar sua própria chave OpenAI',
+    ],
+    cta: 'Assinar Plus',
+    badge: 'Mais Popular',
+    highlighted: true,
+  },
+  {
+    id: 'pro',
+    title: 'Pro',
+    price: 'R$29,90/mês (≈ $6.00)',
+    description: 'Para uso intenso e automações.',
+    bullets: [
+      '1.000.000 de registros',
+      '10M tokens de IA/mês',
+      'Devices ilimitados + novos devices sem limite prático',
+      'Pode usar sua própria chave OpenAI',
+    ],
+    cta: 'Assinar Pro',
+    badge: 'Máximo',
+  },
+];
+
+export interface FeatureRow {
+  feature: string;
+  values: string[];
+}
+
+export const comparisonTable: FeatureRow[] = [
+  {
+    feature: 'Sync na nuvem',
+    values: ['✓', '✓', '✓', '✓'],
+  },
+  {
+    feature: 'Devices conectados ilimitados',
+    values: ['✓', '✓', '✓', '✓'],
+  },
+  {
+    feature: 'Novos devices (full first sync)',
+    values: ['5 vitalício', 'Sem limite prático (monitorado)', 'Sem limite prático', 'Sem limite prático'],
+  },
+  {
+    feature: 'Limite de registros',
+    values: ['5.000', '50.000', '200.000', '1.000.000'],
+  },
+  {
+    feature: 'IA incluída (tokens/mês)',
+    values: ['Somente no onboarding (1x)', '1M', '5M', '10M'],
+  },
+  {
+    feature: 'Onboarding com IA (voz/texto)',
+    values: ['✓ (1x)', '✓', '✓', '✓'],
+  },
+  {
+    feature: 'Usar a própria chave OpenAI (opcional)',
+    values: ['✓', '✓', '✓', '✓'],
+  },
+  {
+    feature: 'Exportar/Importar dados',
+    values: ['✓', '✓', '✓', '✓'],
+  },
+];
+
+export const transparencyNote =
+  'Cobramos valores acessíveis para cobrir Firebase (leituras/escritas/armazenamento) e IA (tokens por uso). Assinantes pagos subsidiam o plano Free. Você pode usar sua própria chave OpenAI em qualquer plano.';


### PR DESCRIPTION
## Summary
- centralize plan details and comparison into shared module
- update subscription pages and table with Free, Basic, Plus, Pro
- add cost and token transparency links

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ea85ff28832eb6ce00d3ba229f0c