### PR TITLE
feat: add monthly filter to timeline

### DIFF
--- a/src/data/repositories/AccountsRepository.ts
+++ b/src/data/repositories/AccountsRepository.ts
@@ -19,7 +19,7 @@ export default class AccountsRepository extends RepositoryWithCrypt<Account> {
     return this.getAccountItems(accountId, showArchived, true).balance;
   }
 
-  public getAccountItems(accountId?: string, showArchived: boolean = false, light: boolean = false): {
+  public getAccountItems(accountId?: string, showArchived: boolean = false, light: boolean = false, includeFuture: boolean = false): {
     registries: RegistryWithDetails[],
     balance: number
   } {
@@ -49,7 +49,7 @@ export default class AccountsRepository extends RepositoryWithCrypt<Account> {
       }));
 
     const registries = ([...debit, ...credit])
-      .filter((item) => item.registry.date.getTime() <= now.getTime())
+      .filter((item) => includeFuture || item.registry.date.getTime() <= now.getTime())
       .sort(({registry: {date: a}}, {registry: {date: b}}) => b.getTime() - a.getTime());
 
     return {

--- a/src/features/tabs/timeline/TimelineScreen.css
+++ b/src/features/tabs/timeline/TimelineScreen.css
@@ -95,3 +95,25 @@
   gap: 12px;
   padding-bottom: 3em;
 }
+
+.TimelineMonthNav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.TimelineMonthNavButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.TimelineMonthLabel {
+  text-transform: capitalize;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add option to include future items when retrieving account registries
- filter timeline by selected month with navigation controls
- style timeline month navigation header

## Testing
- `yarn test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'firebase')*


------
https://chatgpt.com/codex/tasks/task_e_68a75f39be70832e9e7efafbe573865b