### PR TITLE
feat: add purchase state to groceries

### DIFF
--- a/src/data/models/GroceryItemModel.ts
+++ b/src/data/models/GroceryItemModel.ts
@@ -11,6 +11,7 @@ export class GroceryItemModel extends DocumentModel {
     public paidPrice?: number,
     public purchaseDate: Date = new Date(),
     public location?: string,
+    public toBuy: boolean = false,
   ) {
     super(id);
   }

--- a/src/features/beta/GroceryListAiInfo.ts
+++ b/src/features/beta/GroceryListAiInfo.ts
@@ -9,12 +9,13 @@ quantity?: (integer of how many packages are there)
 location?: (where the item is stored)
 expirationDate?: string (when the products will expire)
 paidPrice?: number
+toBuy?: boolean (true if the user needs to buy it, false if already owned)
 `,
   outputExample: `
 Context: there is no rice on list and he just bought it
 User: "i've bought 2 packages with 2kg of rice and the beans are gone"
 Assistant:
-[{ "action": "add", "id": "d52aadfd1", "name": "rice 5kg", quantity: 2 },{ "action": "remove", "id": "beans" }]
+[{ "action": "add", "id": "d52aadfd1", "name": "rice 5kg", quantity: 2, toBuy: false },{ "action": "remove", "id": "beans" }]
 
 Context: there is already a milk on list
 User: "the milk on refrigerator expiry to Friday"

--- a/src/features/beta/SpeechScreen.css
+++ b/src/features/beta/SpeechScreen.css
@@ -1,3 +1,12 @@
 .SpeechScreen {
   position: relative;
 }
+
+.SpeechGroceryLists {
+  display: flex;
+  gap: 16px;
+}
+
+.SpeechGroceryColumn {
+  flex: 1;
+}

--- a/src/features/beta/SpeechScreen.tsx
+++ b/src/features/beta/SpeechScreen.tsx
@@ -12,12 +12,19 @@ import { AIGroceryListConfig } from './GroceryListAiInfo';
 const SpeechScreen = () => {
   const aiParser = useMemo(
     () =>
-      new AIActionsParser<GroceryItemModel>(AIGroceryListConfig, (item) => {
-        if (item.opened !== undefined) item.opened.toString() === 'true';
-        if (item.expirationDate !== undefined)
-          item.expirationDate = new Date(item.expirationDate);
-        return item;
-      }),
+      new AIActionsParser<GroceryItemModel>(
+        AIGroceryListConfig,
+        (item) => {
+          if (item.opened !== undefined)
+            item.opened = item.opened.toString() === 'true';
+          if (item.toBuy !== undefined)
+            item.toBuy = item.toBuy.toString() === 'true';
+          if (item.expirationDate !== undefined)
+            item.expirationDate = new Date(item.expirationDate);
+          return item;
+        },
+        ({ id, name, toBuy }) => ({ id, name, toBuy })
+      ),
     []
   );
 
@@ -46,7 +53,16 @@ const SpeechScreen = () => {
         </ul>
       </ContainerFixedContent>
       <ContainerScrollContent spaced autoScroll>
-        <GroceryList items={groceryItems} />
+        <div className="SpeechGroceryLists">
+          <div className="SpeechGroceryColumn">
+            <h3>Have</h3>
+            <GroceryList items={groceryItems.filter((i) => !i.toBuy)} />
+          </div>
+          <div className="SpeechGroceryColumn">
+            <h3>To Buy</h3>
+            <GroceryList items={groceryItems.filter((i) => i.toBuy)} />
+          </div>
+        </div>
         <div style={{ height: 120 }}></div>
         <AIMicrophone parser={aiParser} onAction={handleAiAction} />
       </ContainerScrollContent>


### PR DESCRIPTION
## Summary
- track whether grocery items still need to be bought
- teach AI parser about buying status
- split grocery items into owned vs shopping lists in beta speech view

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a76108ca80832e9dced327caa96ac3