### PR TITLE
Add AI-driven onboarding flow for accounts and cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import GroceryItemForm from '@features/groceries/GroceryItemForm';
 import GroceriesMainScreen from '@features/groceries/GroceriesMainScreen';
 import GroceriesTrashScreen from '@features/groceries/GroceriesTrashScreen';
 import SubscriptionsRouter from '@features/subscriptions/SubscriptionsRouter';
+import OnboardingRouter from '@features/onboarding/OnboardingRouter';
 
 import { clearRepositories, resetRepositories } from '@repositories';
 import { getCurrentUser, saveUser } from '@configs';
@@ -68,6 +69,7 @@ const privateRouter = createBrowserRouter([
   { path: '/groceries/create', element: <GroceryItemForm /> },
   { path: '/groceries/:id/edit', element: withRepos(<GroceryItemForm />, 'groceries') },
   { path: '/subscriptions/*', element: <SubscriptionsRouter /> },
+  { path: '/onboarding/*', element: <OnboardingRouter /> },
   { path: '*', element: <EmptyScreen title='Not Found' /> },
 ])
 

--- a/src/features/onboarding/AccountsStep.tsx
+++ b/src/features/onboarding/AccountsStep.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Container, ContainerFixedContent, ContainerScrollContent } from '@components/conteiners';
+import Button from '@components/Button';
+import AIMicrophone from '@components/voice/AIMicrophone';
+import AIActionsParser, { AIActionHandler } from '@features/speech/AIParserManager';
+import { accountNormalizer, AccountAiConfig, OnboardingAccount } from './accountAiInfo';
+import { useOnboarding } from './OnboardingContext';
+
+const AccountsStep = () => {
+  const navigate = useNavigate();
+  const { data, update } = useOnboarding();
+  const parser = useMemo(
+    () => new AIActionsParser<OnboardingAccount>(AccountAiConfig, accountNormalizer),
+    []
+  );
+
+  useEffect(() => {
+    parser.items = data.accounts;
+  }, [data.accounts, parser]);
+
+  const handleAction: AIActionHandler<OnboardingAccount> = useCallback(() => {
+    update({ accounts: [...parser.items] });
+  }, [parser, update]);
+
+  return (
+    <Container screen spaced>
+      <ContainerFixedContent>
+        <h2>Bank accounts</h2>
+      </ContainerFixedContent>
+      <ContainerScrollContent spaced autoScroll>
+        <ul>
+          {parser.items.map((acc) => (
+            <li key={acc.id || acc.name}>
+              {acc.name}
+              {acc.bankName ? ` - ${acc.bankName}` : ''}
+              {acc.initialBalance != null ? ` - ${acc.initialBalance}` : ''}
+            </li>
+          ))}
+        </ul>
+        <AIMicrophone parser={parser} onAction={handleAction} />
+        <div style={{ marginTop: 24 }}>
+          <Button text="Next" onClick={() => navigate('../credit-cards')} />
+        </div>
+      </ContainerScrollContent>
+    </Container>
+  );
+};
+
+export default AccountsStep;
+

--- a/src/features/onboarding/CreditCardsStep.tsx
+++ b/src/features/onboarding/CreditCardsStep.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Container, ContainerFixedContent, ContainerScrollContent } from '@components/conteiners';
+import Button from '@components/Button';
+import AIMicrophone from '@components/voice/AIMicrophone';
+import AIActionsParser, { AIActionHandler } from '@features/speech/AIParserManager';
+import { CreditCardAiConfig, creditCardNormalizer, OnboardingCreditCard } from './creditCardAiInfo';
+import { useOnboarding } from './OnboardingContext';
+
+const CreditCardsStep = () => {
+  const navigate = useNavigate();
+  const { data, update } = useOnboarding();
+  const parser = useMemo(
+    () => new AIActionsParser<OnboardingCreditCard>(CreditCardAiConfig, creditCardNormalizer),
+    []
+  );
+
+  useEffect(() => {
+    parser.items = data.creditCards;
+  }, [data.creditCards, parser]);
+
+  const handleAction: AIActionHandler<OnboardingCreditCard> = useCallback(() => {
+    update({ creditCards: [...parser.items] });
+  }, [parser, update]);
+
+  return (
+    <Container screen spaced>
+      <ContainerFixedContent>
+        <h2>Credit cards</h2>
+      </ContainerFixedContent>
+      <ContainerScrollContent spaced autoScroll>
+        <ul>
+          {parser.items.map((card) => (
+            <li key={card.id || card.name}>
+              {card.name}
+              {card.bankName ? ` - ${card.bankName}` : ''}
+              {card.limit != null ? ` - ${card.limit}` : ''}
+            </li>
+          ))}
+        </ul>
+        <AIMicrophone parser={parser} onAction={handleAction} />
+        <div style={{ marginTop: 24 }}>
+          <Button text="Finish" onClick={() => navigate('/main/dashboard')} />
+        </div>
+      </ContainerScrollContent>
+    </Container>
+  );
+};
+
+export default CreditCardsStep;
+

--- a/src/features/onboarding/OnboardingContext.tsx
+++ b/src/features/onboarding/OnboardingContext.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { OnboardingAccount } from './accountAiInfo';
+import { OnboardingCreditCard } from './creditCardAiInfo';
+
+export interface OnboardingData {
+  accounts: OnboardingAccount[];
+  creditCards: OnboardingCreditCard[];
+}
+
+interface OnboardingContextValue {
+  data: OnboardingData;
+  update: (partial: Partial<OnboardingData>) => void;
+}
+
+const STORAGE_KEY = 'onboarding-data';
+
+const OnboardingContext = createContext<OnboardingContextValue>({
+  data: { accounts: [], creditCards: [] },
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  update: () => {},
+});
+
+export const OnboardingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [data, setData] = useState<OnboardingData>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : { accounts: [], creditCards: [] };
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }, [data]);
+
+  const update = (partial: Partial<OnboardingData>) =>
+    setData((prev) => ({ ...prev, ...partial }));
+
+  return (
+    <OnboardingContext.Provider value={{ data, update }}>
+      {children}
+    </OnboardingContext.Provider>
+  );
+};
+
+export const useOnboarding = () => useContext(OnboardingContext);
+

--- a/src/features/onboarding/OnboardingRouter.tsx
+++ b/src/features/onboarding/OnboardingRouter.tsx
@@ -1,0 +1,23 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { OnboardingProvider } from './OnboardingContext';
+import AccountsStep from './AccountsStep';
+import CreditCardsStep from './CreditCardsStep';
+
+export const onboardingSteps = [
+  { path: 'accounts', element: <AccountsStep /> },
+  { path: 'credit-cards', element: <CreditCardsStep /> },
+];
+
+const OnboardingRouter = () => (
+  <OnboardingProvider>
+    <Routes>
+      {onboardingSteps.map((step) => (
+        <Route key={step.path} path={step.path} element={step.element} />
+      ))}
+      <Route path="" element={<Navigate to={onboardingSteps[0].path} replace />} />
+    </Routes>
+  </OnboardingProvider>
+);
+
+export default OnboardingRouter;
+

--- a/src/features/onboarding/accountAiInfo.ts
+++ b/src/features/onboarding/accountAiInfo.ts
@@ -1,0 +1,30 @@
+import { AIConfig, AIItemTransformer } from '@features/speech/AIParserManager';
+
+export interface OnboardingAccount {
+  id?: string;
+  name?: string;
+  bankName?: string;
+  initialBalance?: number;
+  includeInTotal?: boolean;
+}
+
+export const AccountAiConfig: AIConfig = {
+  listDescription: 'user bank accounts to create during onboarding',
+  additionalFields: [
+    { name: 'name', description: 'account name or nickname', type: 'string' },
+    { name: 'bankName', description: 'bank or institution name', type: 'string' },
+    { name: 'initialBalance', description: 'initial balance of the account', type: 'number' },
+    { name: 'includeInTotal', description: 'true if account should appear in totals', type: 'boolean' },
+  ],
+};
+
+export const accountNormalizer: AIItemTransformer<OnboardingAccount> = (item) => {
+  if (item.initialBalance !== undefined) {
+    item.initialBalance = Number(item.initialBalance);
+  }
+  if (item.includeInTotal !== undefined) {
+    item.includeInTotal = String(item.includeInTotal) === 'true';
+  }
+  return item;
+};
+

--- a/src/features/onboarding/creditCardAiInfo.ts
+++ b/src/features/onboarding/creditCardAiInfo.ts
@@ -1,0 +1,25 @@
+import { AIConfig, AIItemTransformer } from '@features/speech/AIParserManager';
+
+export interface OnboardingCreditCard {
+  id?: string;
+  name?: string;
+  bankName?: string;
+  limit?: number;
+}
+
+export const CreditCardAiConfig: AIConfig = {
+  listDescription: 'user credit cards to create during onboarding',
+  additionalFields: [
+    { name: 'name', description: 'credit card name or nickname', type: 'string' },
+    { name: 'bankName', description: 'bank or issuer name', type: 'string' },
+    { name: 'limit', description: 'credit limit of the card', type: 'number' },
+  ],
+};
+
+export const creditCardNormalizer: AIItemTransformer<OnboardingCreditCard> = (item) => {
+  if (item.limit !== undefined) {
+    item.limit = Number(item.limit);
+  }
+  return item;
+};
+


### PR DESCRIPTION
## Summary
- add reusable onboarding context with localStorage persistence
- add AI parsing configs and steps for accounts and credit cards
- wire onboarding router into app navigation

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a827b9ad6c832eac95f2a4f847b562