### PR TITLE
feat: add timeline search

### DIFF
--- a/src/data/utils/SearchScore.ts
+++ b/src/data/utils/SearchScore.ts
@@ -5,6 +5,12 @@ export interface SearchableFields {
   value?: number;
 }
 
+const DESCRIPTION_WEIGHT = 4;
+const NAME_WEIGHT = 1;
+const CATEGORY_WEIGHT = 2;
+const VALUE_WEIGHT = 3;
+const NUMBER_THRESHOLD = 100;
+
 function tokenize(text: string): string[] {
   return text
     .toLowerCase()
@@ -24,12 +30,11 @@ function scoreNumber(token: string, value?: number): number {
   if (value === undefined) return 0;
   const num = Number(token);
   if (isNaN(num)) return 0;
-  const diff = Math.abs(Math.abs(value) - Math.abs(num));
-  if (diff === 0) return 4;
-  if (diff <= 1) return 3;
-  if (diff <= 3) return 2;
-  if (diff <= 10) return 1;
-  return 0;
+  const diff = Math.abs(value - num);
+  if (diff === 0) return 10; // rare exact match bonus
+  if (diff > NUMBER_THRESHOLD) return 0;
+  const proximity = 1 - diff / NUMBER_THRESHOLD; // 0..1
+  return proximity * VALUE_WEIGHT;
 }
 
 export function searchScore(query: string, fields: SearchableFields): number {
@@ -41,9 +46,9 @@ export function searchScore(query: string, fields: SearchableFields): number {
       score += scoreNumber(token, fields.value);
       continue;
     }
-    if (fields.name) score += scoreText(token, fields.name, 3);
-    if (fields.category) score += scoreText(token, fields.category, 3);
-    if (fields.description) score += scoreText(token, fields.description, 1);
+    if (fields.name) score += scoreText(token, fields.name, NAME_WEIGHT);
+    if (fields.category) score += scoreText(token, fields.category, CATEGORY_WEIGHT);
+    if (fields.description) score += scoreText(token, fields.description, DESCRIPTION_WEIGHT);
   }
   return score;
 }

--- a/src/data/utils/SearchScore.ts
+++ b/src/data/utils/SearchScore.ts
@@ -1,0 +1,51 @@
+export interface SearchableFields {
+  description?: string;
+  name?: string;
+  category?: string;
+  value?: number;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .map(t => t.trim())
+    .filter(Boolean);
+}
+
+function scoreText(token: string, field: string, weight: number): number {
+  const lower = field.toLowerCase();
+  if (lower === token) return weight * 2; // exact match
+  if (lower.includes(token)) return weight; // partial match
+  return 0;
+}
+
+function scoreNumber(token: string, value?: number): number {
+  if (value === undefined) return 0;
+  const num = Number(token);
+  if (isNaN(num)) return 0;
+  const diff = Math.abs(Math.abs(value) - Math.abs(num));
+  if (diff === 0) return 4;
+  if (diff <= 1) return 3;
+  if (diff <= 3) return 2;
+  if (diff <= 10) return 1;
+  return 0;
+}
+
+export function searchScore(query: string, fields: SearchableFields): number {
+  const tokens = tokenize(query);
+  let score = 0;
+  for (const token of tokens) {
+    const num = Number(token);
+    if (!isNaN(num)) {
+      score += scoreNumber(token, fields.value);
+      continue;
+    }
+    if (fields.name) score += scoreText(token, fields.name, 3);
+    if (fields.category) score += scoreText(token, fields.category, 3);
+    if (fields.description) score += scoreText(token, fields.description, 1);
+  }
+  return score;
+}
+
+export default searchScore;

--- a/src/features/tabs/timeline/TimelineScreen.tsx
+++ b/src/features/tabs/timeline/TimelineScreen.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import "./TimelineScreen.css";
 
 import { Month, MonthKey } from '@utils/FinancialMonthPeriod';
@@ -13,11 +13,9 @@ import { ContainerScrollContent } from '@components/conteiners';
 import { Loading } from "@components/Loading";
 import Icon from '@components/Icons';
 import SearchBar from '@components/fields/SearchBar';
-import searchScore from '@utils/SearchScore';
 
 import { PARAM_CATEGORY, PARAM_FROM, PARAM_TO } from './TimelineFilterScreen';
 import RegistryItem from "./RegistryItem";
-import { a } from 'vitest/dist/chunks/suite.d.FvehnV49';
 
 const formatNumber = (number: number) => number.toLocaleString(navigator.language, {
   style: "currency",
@@ -53,29 +51,13 @@ const TimelineScreen = () => {
       period: searchValue ? undefined : period,
       accountIds,
       categoryIds,
-      showArchived
+      showArchived,
+      search: searchValue,
     });
 
     setCurrentBalance(balance.getBalance(accountIds, period.end));
     setRegistries(registries);
   }, [categoryIds, accountIds, showArchived, period, searchValue]);
-
-  const displayedRegistries = useMemo(() => {
-    if (!searchValue.trim()) return registries;
-    return registries
-      .map(r => ({
-        item: r,
-        score: searchScore(searchValue, {
-          description: r.registry.description,
-          name: r.sourceName,
-          category: r.category?.name,
-          value: r.registry.value,
-        })
-      }))
-      .filter(r => r.score > 0)
-      .sort((a, b) => b.score - a.score)
-      .map(r => r.item);
-  }, [searchValue, registries]);
 
   const { id: accountId} = useParams<{ id?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -129,7 +111,7 @@ const TimelineScreen = () => {
 
   // TODO
   let perDayTotal = 0;
-  let currentDay = displayedRegistries[0]?.registry.date.getDate();
+  let currentDay = registries[0]?.registry.date.getDate();
   return <Container spaced full>
     <ContainerFixedContent>
       <div className="ScreenHeaderRow">
@@ -167,7 +149,7 @@ const TimelineScreen = () => {
             {formatNumber(currentBalance)}
           </span>}
         </div>
-        {displayedRegistries.length !== 0 && <span className="RegistryCount">({displayedRegistries.length}) {Lang.timeline.registryCount}</span>}
+        {registries.length !== 0 && <span className="RegistryCount">({registries.length}) {Lang.timeline.registryCount}</span>}
       </div>
       <div className="TimelineMonthNav">
         <button className="TimelineMonthNavButton" onClick={() => changeMonth(false)}>
@@ -192,7 +174,7 @@ const TimelineScreen = () => {
     </ContainerFixedContent>
     <ContainerScrollContent>
       <div className="TimelineList">
-        {displayedRegistries.map(item => {
+        {registries.map(item => {
           const { id, value, date } = item.registry;
           const isCurrentDay = date.getDate() === currentDay;
           if (!isCurrentDay) {


### PR DESCRIPTION
## Summary
- add search score utility to rank results
- integrate search bar and scoring into timeline screen

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68aefa486b44832ebe2aca7c3f7e16fe