### PR TITLE
feat: add timeline finance preferences

### DIFF
--- a/src/data/service/index.ts
+++ b/src/data/service/index.ts
@@ -1,6 +1,7 @@
 import getRepositories, { Repositories } from "@repositories";
 import { BalanceService } from "./BalanceService";
 import TimelineService from "./TimelineService";
+import FinancialMonthPeriod from "../utils/FinancialMonthPeriod";
 import { getCurrentUser } from "@configs";
 
 export type Services = {
@@ -22,10 +23,14 @@ let servicesInstances: ServicesInstance | null = null;
 export function resetServices(uid: string, repositories: Repositories): Services {
   if (servicesInstances?.uid === uid) return servicesInstances.instances;
 
-  const timeline = new TimelineService(repositories);
+  const cutOff = parseInt(localStorage.getItem('financeDay') || '1');
+  const mode = (localStorage.getItem('financeMode') as "start" | "next") || 'start';
+  const period = new FinancialMonthPeriod(cutOff, mode);
+
+  const timeline = new TimelineService(repositories, period);
   const instances: Services = {
     timeline,
-    balance: new BalanceService(timeline),
+    balance: new BalanceService(timeline, period),
   };
 
   servicesInstances = { uid, instances };

--- a/src/data/utils/FinancialMonthPeriod.ts
+++ b/src/data/utils/FinancialMonthPeriod.ts
@@ -23,13 +23,33 @@ const CUTOFF_MAX_DAY = 28;
 
 export default class FinancialMonthPeriod {
   constructor(
-    private readonly cutOffDay: number = 1,
+    private cutOffDay: number = 1,
     private displayType: "start" | "next" = "start"
   ) {
     if (cutOffDay < 1 || cutOffDay > CUTOFF_MAX_DAY) {
       throw new Error(`Cut-off day must be between 1 and ${CUTOFF_MAX_DAY}.`);
     }
     this.cutOffDay = cutOffDay;
+  }
+
+  public setConfig({ cutOffDay, displayType }: { cutOffDay?: number; displayType?: "start" | "next" }): void {
+    if (cutOffDay !== undefined) {
+      if (cutOffDay < 1 || cutOffDay > CUTOFF_MAX_DAY) {
+        throw new Error(`Cut-off day must be between 1 and ${CUTOFF_MAX_DAY}.`);
+      }
+      this.cutOffDay = cutOffDay;
+    }
+    if (displayType) {
+      this.displayType = displayType;
+    }
+  }
+
+  public getCutOffDay(): number {
+    return this.cutOffDay;
+  }
+
+  public getDisplayType(): "start" | "next" {
+    return this.displayType;
   }
 
   public getMonthPeriod(month: Month): Period {

--- a/src/features/tabs/settings/SettingsScreen.tsx
+++ b/src/features/tabs/settings/SettingsScreen.tsx
@@ -8,6 +8,7 @@ import AppSection from './sections/AppPreferencesSection';
 import AccountSection from './sections/AccountSection';
 import BetaSection from './sections/BetaSection';
 import DevSection from './sections/DevSection';
+import PreferencesSection from './sections/PreferencesSection';
 import { SettingsSection } from './sections/types';
 
 const SettingsScreen = () => {
@@ -15,6 +16,7 @@ const SettingsScreen = () => {
   const sections: SettingsSection[] = useMemo(() => ([
     FinancesSection,
     AccountSection,
+    PreferencesSection,
     AppSection,
     BetaSection,
     DevSection,

--- a/src/features/tabs/settings/sections/PreferencesSection.tsx
+++ b/src/features/tabs/settings/sections/PreferencesSection.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { SettingsSection } from './types';
+import { getServices } from '@services';
+
+const TimelinePreferences = () => {
+  const { period } = getServices().timeline;
+  const [mode, setMode] = useState(period.getDisplayType());
+  const [day, setDay] = useState(period.getCutOffDay());
+
+  const handleModeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newMode = e.target.value as 'start' | 'next';
+    setMode(newMode);
+    period.setConfig({ displayType: newMode });
+    localStorage.setItem('financeMode', newMode);
+  };
+
+  const handleDayChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newDay = parseInt(e.target.value, 10);
+    setDay(newDay);
+    period.setConfig({ cutOffDay: newDay });
+    localStorage.setItem('financeDay', String(newDay));
+  };
+
+  return <div className="TimelineSettings">
+    <div>
+      <strong>{Lang.settings.timelineMode}</strong>
+      <select value={mode} onChange={handleModeChange}>
+        <option value="start">{Lang.settings.timelineModeStart}</option>
+        <option value="next">{Lang.settings.timelineModeNext}</option>
+      </select>
+    </div>
+    <div>
+      <strong>{Lang.settings.timelineCutoffDay}</strong>
+      <select value={day} onChange={handleDayChange}>
+        {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
+          <option key={d} value={d}>{d}</option>
+        ))}
+      </select>
+    </div>
+  </div>;
+};
+
+const section: SettingsSection = {
+  id: 'preferences',
+  title: 'Preferências',
+  content: <TimelinePreferences />
+};
+
+export default section;

--- a/src/features/tabs/timeline/TimelineScreen.css
+++ b/src/features/tabs/timeline/TimelineScreen.css
@@ -104,6 +104,12 @@
   margin-bottom: var(--spacing-md);
 }
 
+.TimelineMonthInfo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .TimelineMonthNavButton {
   background: none;
   border: none;
@@ -116,4 +122,8 @@
 .TimelineMonthLabel {
   text-transform: capitalize;
   font-weight: bold;
+}
+
+.TimelineMonthPeriod {
+  font-size: 0.8em;
 }

--- a/src/features/tabs/timeline/TimelineScreen.tsx
+++ b/src/features/tabs/timeline/TimelineScreen.tsx
@@ -161,9 +161,14 @@ const TimelineScreen = () => {
         <button className="TimelineMonthNavButton" onClick={() => changeMonth(false)}>
           <Icon icon={Icon.all.faChevronLeft} />
         </button>
-        <span className="TimelineMonthLabel">
-          {currentMonth.localeName}
-        </span>
+        <div className="TimelineMonthInfo">
+          <span className="TimelineMonthLabel">
+            {currentMonth.localeName}
+          </span>
+          <span className="TimelineMonthPeriod">
+            {period.start.toLocaleDateString(navigator.language)} - {period.end.toLocaleDateString(navigator.language)}
+          </span>
+        </div>
         <button className="TimelineMonthNavButton" onClick={() => changeMonth(true)}>
           <Icon icon={Icon.all.faChevronRight} />
         </button>

--- a/src/i18n/base.ts
+++ b/src/i18n/base.ts
@@ -115,6 +115,10 @@ export default interface Translation {
     language: string;
     toggleEncryption: (isDisabled: boolean) => string;
     resavingWithEncryption: (filename: string, current: string, max: string) => string;
+    timelineMode: string;
+    timelineModeStart: string;
+    timelineModeNext: string;
+    timelineCutoffDay: string;
   };
   dashboard: {
     title: string;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -118,6 +118,10 @@ const en: Translation = {
     language: 'Language',
     toggleEncryption: (disabled: boolean) => disabled ? 'Enable Encryption (DEV only)' : 'Disable Encryption (DEV only)',
     resavingWithEncryption: (filename: string, current: string, max: string) => `Resaving ${filename} (${current}/${max})...`,
+    timelineMode: 'Timeline mode',
+    timelineModeStart: 'Start',
+    timelineModeNext: 'Next',
+    timelineCutoffDay: 'Cut-off day',
   },
   dashboard: {
     title: 'Dashboard',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -107,6 +107,10 @@ const es: Translation = {
     language: 'Idioma',
     toggleEncryption: (disabled: boolean) => disabled ? 'Habilitar Cifrado (DEV only)' : 'Deshabilitar Cifrado (DEV only)',
     resavingWithEncryption: (filename: string, current: string, max: string) => `Guardando nuevamente ${filename} (${current}/${max})...`,
+    timelineMode: 'Modo de timeline',
+    timelineModeStart: 'Inicio',
+    timelineModeNext: 'Siguiente',
+    timelineCutoffDay: 'Día de corte',
   },
   dashboard: {
     title: 'Tablero',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -107,6 +107,10 @@ const fr: Translation = {
     language: 'Langue',
     toggleEncryption: (disabled: boolean) => disabled ? 'Activer le Chiffrement (DEV only)' : 'Désactiver le Chiffrement (DEV only)',
     resavingWithEncryption: (filename: string, current: string, max: string) => `Réenregistrement de ${filename} (${current}/${max})...`,
+    timelineMode: 'Mode de timeline',
+    timelineModeStart: 'Début',
+    timelineModeNext: 'Suivant',
+    timelineCutoffDay: 'Jour de coupure',
   },
   dashboard: {
     title: 'Tableau de Bord',

--- a/src/i18n/hi.ts
+++ b/src/i18n/hi.ts
@@ -117,6 +117,10 @@ const hi: Translation = {
     language: 'भाषा',
     toggleEncryption: (disabled: boolean) => disabled ? 'एन्क्रिप्शन सक्षम करें (केवल DEV)' : 'एन्क्रिप्शन अक्षम करें (केवल DEV)',
     resavingWithEncryption: (filename: string, current: string, max: string) => `${filename} फिर से सहेजा जा रहा है (${current}/${max})...`,
+    timelineMode: 'टाइमलाइन मोड',
+    timelineModeStart: 'प्रारंभ',
+    timelineModeNext: 'अगला',
+    timelineCutoffDay: 'कट-ऑफ दिन',
   },
   dashboard: {
     title: 'डैशबोर्ड',

--- a/src/i18n/ptBR.ts
+++ b/src/i18n/ptBR.ts
@@ -119,6 +119,10 @@ const ptBR: Translation = {
     language: 'Idioma',
     toggleEncryption: (disabled: boolean) => disabled ? 'Ativar Criptografia (DEV only)' : 'Desativar Criptografia (DEV only)',
     resavingWithEncryption: (filename: string, current: string, max: string) => `Salvando novamente ${filename} (${current}/${max})...`,
+    timelineMode: 'Modo da timeline',
+    timelineModeStart: 'Início',
+    timelineModeNext: 'Próximo',
+    timelineCutoffDay: 'Dia de corte',
   },
   dashboard: {
     title: 'Visão Geral',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -107,6 +107,10 @@ const zh: Translation = {
     language: '语言',
     toggleEncryption: (disabled: boolean) => disabled ? '启用加密 (DEV only)' : '禁用加密 (DEV only)',
     resavingWithEncryption: (filename: string, current: string, max: string) => `重新保存 ${filename} (${current}/${max})...`,
+    timelineMode: '时间线模式',
+    timelineModeStart: '起始',
+    timelineModeNext: '下一个',
+    timelineCutoffDay: '截断日',
   },
   dashboard: {
     title: '仪表板',


### PR DESCRIPTION
## Summary
- add configurable financial month period
- show selected period on timeline header
- expose timeline finance settings under preferences

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68af42f96a04832e87969105d1f104cf